### PR TITLE
replaceState is called on unmounted component

### DIFF
--- a/src/RouteContainer.js
+++ b/src/RouteContainer.js
@@ -18,18 +18,31 @@ export const RouteContainer = React.createClass({
   },
 
 
+  componentWillMount() {
+    this.unsubscribe = null;
+  },
+
+
   componentDidMount() {
-    this.unsubscribe = this.context.getComponentRouterStore().subscribe(this.onChange);
+    if (!this.unsubscribe) {
+      this.unsubscribe = this.context.getComponentRouterStore()
+        .subscribe(this.onChange);
+    }
   },
 
 
   componentWillUnmount() {
-    this.unsubscribe();
+    if (this.unsubscribe) {
+      this.unsubscribe();
+      this.unsubscribe = null;
+    }
   },
 
 
   onChange() {
-    this.replaceState(this.context.getComponentRouterState());
+    if (this.unsubscribe) {
+      this.replaceState(this.context.getComponentRouterState());
+    }
   },
 
 

--- a/src/UrlContainer.js
+++ b/src/UrlContainer.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import {actions, href, isActive} from 'component-router';
+import {RouteContainer} from './';
 
 
 export const UrlContainer = React.createClass({
@@ -11,23 +12,7 @@ export const UrlContainer = React.createClass({
 
 
   contextTypes: {
-    getComponentRouterStore: React.PropTypes.func,
-    getComponentRouterState: React.PropTypes.func
-  },
-
-
-  getInitialState() {
-    return this.context.getComponentRouterState();
-  },
-
-
-  componentDidMount() {
-    this.unsubscribe = this.context.getComponentRouterStore().subscribe(this.onChange);
-  },
-
-
-  componentWillUnmount() {
-    this.unsubscribe();
+    getComponentRouterStore: React.PropTypes.func
   },
 
 
@@ -43,24 +28,24 @@ export const UrlContainer = React.createClass({
       // React only on normal left-button clicks
       if (this.isLMB(event)) {
         event.preventDefault();
-        this.context.getComponentRouterStore().dispatch(actions.navigateTo({query, pathname}));
+        this.context.getComponentRouterStore()
+          .dispatch(actions.navigateTo({query, pathname}));
       }
     };
-  },
-
-
-  onChange() {
-    this.replaceState(this.context.getComponentRouterState());
   },
 
 
   render() {
     const {children: render, query, pathname} = this.props;
 
-    return render({
-      href: href(this.state, {query, pathname}),
-      onClick: this.onClick({query, pathname}),
-      'data-active': isActive(this.state, {query, pathname})
-    });
+    return (
+      <RouteContainer>
+        {state => render({
+          href: href(state, {query, pathname}),
+          onClick: this.onClick({query, pathname}),
+          'data-active': isActive(state, {query, pathname})
+        })}
+      </RouteContainer>
+    );
   }
 });


### PR DESCRIPTION
Fixes #6 

Due to async nature of this things, when we unsubscribe from changes `this.onChange` still can be called internally in Redux, so we now check if we already unsubscribed every time before actually updating state.

Plus removed some code duplication from UrlContainer, effectively wrapping it into RouteContainer.
